### PR TITLE
Mwilson/systemd services

### DIFF
--- a/reactive/hacluster.py
+++ b/reactive/hacluster.py
@@ -40,9 +40,9 @@ def configure_hacluster():
                                                    'desired_services': {},
                                                    'deleted_services': {}})
     for name, service in services['deleted_services'].items():
-        hacluster.remove_init_service(name, service)
+        hacluster.remove_systemd_service(name, service)
     for name, service in services['desired_services'].items():
-        hacluster.add_init_service(name, service)
+        hacluster.add_systemd_service(name, service)
         services['current_services'][name] = service
 
     services['deleted_services'] = {}


### PR DESCRIPTION
systemd shim appears to have disappeared or possibly never worked. The hacluster charm now complains about the services missing and it is a result of using upstart services and not finding snap systemd services. Changing over to use systemd.

Tested with k8s 1.15 from master as a base install and also installed 1.15/stable CK with hacluster and saw the issue and then upgraded to my built charm and saw things correct themselves.

Depends on https://review.opendev.org/#/c/682129/
Fixes: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1841005