### PR TITLE
HACluster - Removing master services from Pacemaker and leaving to Systemd

### DIFF
--- a/reactive/hacluster.py
+++ b/reactive/hacluster.py
@@ -39,7 +39,7 @@ def do_upgrade():
         set_flag('layer-hacluster.upgraded-systemd')
 
 
-@when('ha.connected', 'layer.hacluster.services_configured')
+@when('ha.connected')
 @when_not('layer-hacluster.configured')
 def configure_hacluster():
     """Configure HA resources in corosync"""


### PR DESCRIPTION
Currently, charm-hacluster is not fully prepared to receive kubernetes master services
for some reasons:

1. charm-hacluster doesn’t wait to receive all constraints of order and colocation necessary
to run master services without conflict. Kube-apiserver should be running in a node before
Pacemaker tries to start kube-controller-manager in the same node. [1]

2. Master services are cloned (running in all nodes) with Pacemaker and not grouped with
VIP resources, meaning that if a resource starts to fail in a node that hosts the VIP,
it won’t try to change node leaving the VIP in a unit where it’s not healthy. [2]

3. Resources added with the hacluster-interface have the `migration-threshold` set to
`INFINITY`. This means that the cluster will try to recover the service in the node forever.
In a scenario where just restarting the service is not able to recover the service, Pacemaker
won’t change the VIP to another node even if it’s grouped with the master services. [3]

This is a short-term fix until the problems above are solved.

[1] https://bugs.launchpad.net/charm-hacluster/+bug/1952492
[2] https://bugs.launchpad.net/charm-interface-hacluster/+bug/1952753
[3] https://github.com/openstack/charm-interface-hacluster/blob/master/interface_hacluster/common.py#L993-L1009